### PR TITLE
fix output bug if symbolization failed

### DIFF
--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -281,8 +281,8 @@ bool SymbolizeFile(DbgEng_t &Dbg, const fs::path &Input,
 
     auto AddressSymbolized = Dbg.Symbolize(Address, Opts.Style);
     if (!AddressSymbolized.has_value()) {
-      fmt::print("{}:{}: Symbolization of {} failed ('{}'), skipping\n",
-                 Input.filename().string(), LineNumber, Address, Line);
+      fmt::print("{}:{}: Symbolization of {} failed, skipping\n",
+                 Input.filename().string(), LineNumber, Address);
       NumberFailedSymbolization++;
       continue;
     }


### PR DESCRIPTION
"Line" is not the line and therefore it outputs all addresses and the symbolizer takes endless to finish.

Example of an output before:
aggregate2.cov:173: Symbolization of 2635667410264 failed ('0x7ff99b1a5180 0xfffff802230d7495
0x7ff986dc2d5f
0xfffff8021f604d47
0xfffff8021f486345
0x7ff99b1a5259
0x7ff986e72132
[...] endless addresses in stdout